### PR TITLE
Add REST API workflow example

### DIFF
--- a/docs/open-source-overview.mdx
+++ b/docs/open-source-overview.mdx
@@ -1,0 +1,8 @@
+---
+title: "Community Edition Overview"
+description: "Features available in the open source release"
+---
+
+The Community edition is released under the MIT license and provides **all the pieces and features needed to build and run flows without any limitations.** Enterprise add-ons live under the `packages/ee` folder and require a commercial license.
+
+Refer to [docs/about/editions](about/editions.mdx) for a full comparison.

--- a/examples/workflow-api/README.md
+++ b/examples/workflow-api/README.md
@@ -1,0 +1,36 @@
+# Workflow API Example
+
+This example demonstrates creating a new workflow and updating one of its steps using the REST API.
+
+## Prerequisites
+
+- Node.js installed
+- An Activepieces instance running (Community edition works)
+- An API key and project ID
+
+Set these environment variables before running:
+
+```bash
+export API_BASE_URL=http://localhost:3000/api/v1
+export AP_API_KEY=<your-api-key>
+export PROJECT_ID=<your-project-id>
+```
+
+## Usage
+
+Install dependencies and execute the script:
+
+```bash
+npm install node-fetch
+node createAndUpdateFlow.js
+```
+
+The script performs the following:
+
+1. **Create Flow** – `POST /v1/flows`
+2. **Import Flow Definition** – `POST /v1/flows/{id}` with `IMPORT_FLOW`
+3. **Update Action Step** – `POST /v1/flows/{id}` with `UPDATE_ACTION`
+
+Check the console output for newly created flow ID and status messages.
+
+For full API details see the [OpenAPI specification](../../docs/openapi.json).

--- a/examples/workflow-api/createAndUpdateFlow.js
+++ b/examples/workflow-api/createAndUpdateFlow.js
@@ -1,0 +1,94 @@
+const fetch = require('node-fetch');
+
+const API_BASE_URL = process.env.API_BASE_URL || 'http://localhost:3000/api/v1';
+const API_KEY = process.env.AP_API_KEY || 'YOUR_API_KEY';
+const PROJECT_ID = process.env.PROJECT_ID || 'YOUR_PROJECT_ID';
+
+async function request(path, method, body) {
+  const res = await fetch(`${API_BASE_URL}${path}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${API_KEY}`,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Request failed (${res.status}): ${text}`);
+  }
+  if (res.status === 204) return null;
+  return res.json();
+}
+
+async function run() {
+  const flow = await request('/flows', 'POST', {
+    displayName: 'API Demo Flow',
+    projectId: PROJECT_ID,
+  });
+  console.log('Created flow', flow.id);
+
+  const trigger = {
+    name: 'trigger',
+    displayName: 'Every Day',
+    valid: true,
+    type: 'PIECE_TRIGGER',
+    settings: {
+      pieceName: 'schedule',
+      pieceVersion: '0.1.5',
+      pieceType: 'OFFICIAL',
+      packageType: 'REGISTRY',
+      triggerName: 'every_day',
+      input: {
+        hour_of_the_day: 0,
+        timezone: 'UTC',
+        run_on_weekends: false,
+      },
+      inputUiInfo: {},
+    },
+  };
+
+  const action = {
+    name: 'step_1',
+    displayName: 'Map Data',
+    valid: true,
+    type: 'PIECE',
+    settings: {
+      packageType: 'REGISTRY',
+      pieceType: 'OFFICIAL',
+      pieceName: 'data-mapper',
+      pieceVersion: '0.3.6',
+      actionName: 'advanced_mapping',
+      input: { mapping: { newProperty: 'value' } },
+      inputUiInfo: {},
+    },
+  };
+
+  trigger.nextAction = action;
+
+  await request(`/flows/${flow.id}`, 'POST', {
+    type: 'IMPORT_FLOW',
+    request: {
+      displayName: 'API Demo Flow',
+      trigger,
+      schemaVersion: null,
+    },
+  });
+  console.log('Imported flow definition');
+
+  const updatedAction = {
+    ...action,
+    settings: { ...action.settings, input: { mapping: { changed: true } } },
+  };
+
+  await request(`/flows/${flow.id}`, 'POST', {
+    type: 'UPDATE_ACTION',
+    request: updatedAction,
+  });
+  console.log('Updated action');
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- document that the community edition is fully open source
- add an example demonstrating creating and updating a flow via the API

## Testing
- `npm test` *(fails: Missing script)*
- `npx nx --help` *(fails: network access needed)*

------
https://chatgpt.com/codex/tasks/task_e_6854c09042dc832c9c2abecda10955f5